### PR TITLE
Critical notif

### DIFF
--- a/app.json
+++ b/app.json
@@ -40,6 +40,12 @@
       "permissions": ["RECEIVE_BOOT_COMPLETED", "SCHEDULE_EXACT_ALARM", "WAKE_LOCK"]
     },
     "plugins": [
+      [
+        "expo-font",
+        {
+          "fonts": ["./assets/fonts/Roboto-Regular.ttf", "./assets/fonts/Roboto-Medium.ttf"]
+        }
+      ],
       "expo-font",
       [
         "expo-notifications",

--- a/app.json
+++ b/app.json
@@ -26,7 +26,10 @@
         "NSUserNotificationsUsageDescription": "We need to send you prayer time notifications",
         "UIBackgroundModes": ["fetch"]
       },
-      "backgroundColor": "#2c1c77"
+      "backgroundColor": "#2c1c77",
+      "entitlements": {
+        "com.apple.developer.usernotifications.critical-alerts": true
+      }
     },
     "android": {
       "adaptiveIcon": {
@@ -34,7 +37,7 @@
         "backgroundColor": "#2c1c77"
       },
       "package": "com.mugtaba.athan",
-      "permissions": ["RECEIVE_BOOT_COMPLETED"]
+      "permissions": ["RECEIVE_BOOT_COMPLETED", "SCHEDULE_EXACT_ALARM", "WAKE_LOCK"]
     },
     "plugins": [
       "expo-font",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,16 +1,12 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
-
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
-import { useFonts } from 'expo-font';
 import { Slot } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { LogBox } from 'react-native';
 import { SystemBars } from 'react-native-edge-to-edge';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import BottomSheetSound from '@/components/BottomSheetSound';
-import Error from '@/components/Error';
 
 // Prevent splash screen from automatically hiding
 SplashScreen.preventAutoHideAsync();
@@ -19,22 +15,9 @@ SplashScreen.preventAutoHideAsync();
 LogBox.ignoreLogs(['Require cycle']);
 
 export default function Layout() {
-  const [isReady, setIsReady] = useState(false);
-
-  const [fontsLoaded, fontError] = useFonts({
-    Roboto: require('@/assets/fonts/Roboto-Regular.ttf'),
-    'Roboto-Medium': require('@/assets/fonts/Roboto-Medium.ttf'),
-  });
-
   useEffect(() => {
-    if (!fontsLoaded) return;
-
     SplashScreen.hideAsync();
-    setIsReady(true);
-  }, [fontsLoaded]);
-
-  if (fontError) return <Error />;
-  if (!isReady) return null;
+  }, []);
 
   return (
     <GestureHandlerRootView style={{ flex: 1, backgroundColor: '#2c1c77' }}>

--- a/components/List.tsx
+++ b/components/List.tsx
@@ -37,6 +37,12 @@ export default function List({ type }: Props) {
     longestPrayer = prayers[longestIndex];
   }
 
+  /**
+   * Measures the width of the longest prayer name to ensure consistent layout
+   * This hidden text component runs once on initial render and saves the width
+   * to persistent storage. The stored width is then used by all Prayer components
+   * to maintain equal column widths across the app.
+   */
   const handleHiddenLayout = (e: LayoutChangeEvent) => {
     if (storedWidth !== 0) return;
 

--- a/device/notifications.ts
+++ b/device/notifications.ts
@@ -30,7 +30,7 @@ export const addOneScheduledNotificationForPrayer = async (
   time: string,
   alertType: AlertType
 ): Promise<NotificationUtils.ScheduledNotification> => {
-  const sound = await NotificationStore.getSoundPreference();
+  const sound = NotificationStore.getSoundPreference();
   const triggerDate = NotificationUtils.genTriggerDate(date, time);
   const content = NotificationUtils.genNotificationContent(englishName, arabicName, alertType, sound);
 

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -23,7 +23,7 @@ export const TIME_ADJUSTMENTS = {
 
 export const TEXT = {
   family: {
-    regular: 'Roboto',
+    regular: 'Roboto-Regular',
     medium: 'Roboto-Medium',
   },
   size: 18,

--- a/shared/notifications.ts
+++ b/shared/notifications.ts
@@ -47,7 +47,7 @@ export const genNotificationContent = (
     title: englishName,
     body: `\u200E${arabicName}`, // LTR mark
     sound: getNotificationSound(alertType, soundIndex) || undefined,
-    color: '#2c1c77',
+    color: '#5a3af7',
     autoDismiss: false,
     sticky: false,
     priority: Notifications.AndroidNotificationPriority.MAX,

--- a/shared/notifications.ts
+++ b/shared/notifications.ts
@@ -42,11 +42,16 @@ export const genNotificationContent = (
   arabicName: string,
   alertType: AlertType,
   soundIndex: number
-) => {
+): Notifications.NotificationContentInput => {
   return {
     title: englishName,
     body: `\u200E${arabicName}`, // LTR mark
     sound: getNotificationSound(alertType, soundIndex) || undefined,
+    color: '#2c1c77',
+    autoDismiss: false,
+    sticky: false,
+    priority: Notifications.AndroidNotificationPriority.MAX,
+    interruptionLevel: 'critical',
   };
 };
 


### PR DESCRIPTION
This pull request includes several changes to the application configuration, layout, and notification handling. The most important changes include adding critical alerts entitlements, removing unnecessary font loading logic, making the `List` component reactive to date changes, and updating notification content properties.

### Configuration Updates:
* [`app.json`](diffhunk://#diff-96677aa35debfefd031d9d34d9c70369754ee3acb2d9a9d4090e98612efee6f5L29-R48): Added critical alerts entitlement for iOS and new permissions for Android. Also added custom fonts using `expo-font` plugin.

### Layout and Component Updates:
* [`app/_layout.tsx`](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L1-L13): Removed unnecessary font loading logic and error handling related to fonts. [[1]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L1-L13) [[2]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L22-R20)
* [`components/List.tsx`](diffhunk://#diff-130f9383837edf02a7976b3069f89bec105d4b0005a953ebbb16357e71dc2bf7R9-R38): Made the `List` component reactive to date changes and dynamically calculated schedule length based on the current date. [[1]](diffhunk://#diff-130f9383837edf02a7976b3069f89bec105d4b0005a953ebbb16357e71dc2bf7R9-R38) [[2]](diffhunk://#diff-130f9383837edf02a7976b3069f89bec105d4b0005a953ebbb16357e71dc2bf7L50-R74)

### Notification Handling Updates:
* [`device/notifications.ts`](diffhunk://#diff-5dbad853b2108a3358e4cd77f4281d4e99c39d689ba66f38a38706328728c805L33-R33): Simplified sound preference retrieval by removing the `await` keyword.
* [`shared/notifications.ts`](diffhunk://#diff-0c62118a1fcaea31668ca5bffac92618b7a9aaf3fe8a2806832e851ae2fbe1dbL45-R54): Updated notification content properties to include `color`, `autoDismiss`, `sticky`, `priority`, and `interruptionLevel`.

### Font and Text Updates:
* [`shared/constants.ts`](diffhunk://#diff-3544a8dcc38f34717933ffd577d0377370a611411cd6f645685540c526713566L26-R26): Updated font family names to match the file names used in the project.