### PR TITLE
Permissions

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,7 @@
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { Slot } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import { LogBox, Text } from 'react-native';
 import { SystemBars } from 'react-native-edge-to-edge';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -23,8 +23,8 @@ Text.defaultProps = {
 };
 
 export default function Layout() {
-  useEffect(() => {
-    SplashScreen.hideAsync();
+  useLayoutEffect(() => {
+    SplashScreen.hide();
   }, []);
 
   return (

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,6 +7,7 @@ import { SystemBars } from 'react-native-edge-to-edge';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import BottomSheetSound from '@/components/BottomSheetSound';
+import InitialWidthMeasurement from '@/components/InitialWidthMeasurement';
 
 // Prevent splash screen from automatically hiding
 SplashScreen.preventAutoHideAsync();
@@ -30,6 +31,7 @@ export default function Layout() {
   return (
     <GestureHandlerRootView style={{ flex: 1, backgroundColor: '#2c1c77' }}>
       <SystemBars style="light" />
+      <InitialWidthMeasurement />
       <BottomSheetModalProvider>
         <Slot />
         <BottomSheetSound />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,6 +8,10 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import BottomSheetSound from '@/components/BottomSheetSound';
 import InitialWidthMeasurement from '@/components/InitialWidthMeasurement';
+import { triggerSyncLoadable } from '@/stores/sync';
+
+// Call API During App Start in background
+setTimeout(triggerSyncLoadable, 0);
 
 // Prevent splash screen from automatically hiding
 SplashScreen.preventAutoHideAsync();

--- a/components/InitialWidthMeasurement.tsx
+++ b/components/InitialWidthMeasurement.tsx
@@ -1,0 +1,46 @@
+import { useAtomValue } from 'jotai';
+import { Text, StyleSheet } from 'react-native';
+
+import { TEXT, PRAYERS_ENGLISH, EXTRAS_ENGLISH } from '@/shared/constants';
+import { getLongestPrayerNameIndex } from '@/shared/prayer';
+import { ScheduleType } from '@/shared/types';
+import { setEnglishWidth, englishWidthStandardAtom, englishWidthExtraAtom } from '@/stores/ui';
+
+/**
+ * Measures the width of the longest prayer name for both standard and extra schedules
+ * This component runs during app initialization while splash screen is visible
+ * The measured widths are saved to persistent storage and used by all Prayer components
+ * to maintain equal column widths across the app
+ */
+export default function InitialWidthMeasurement() {
+  const standardWidth = useAtomValue(englishWidthStandardAtom);
+  const extraWidth = useAtomValue(englishWidthExtraAtom);
+
+  return (
+    <>
+      {/* Hidden text elements only render when we need to calculate the width */}
+      {standardWidth === 0 && (
+        <Text
+          style={styles.hidden}
+          onLayout={(e) => setEnglishWidth(ScheduleType.Standard, e.nativeEvent.layout.width)}>
+          {PRAYERS_ENGLISH[getLongestPrayerNameIndex(ScheduleType.Standard)]}
+        </Text>
+      )}
+      {extraWidth === 0 && (
+        <Text style={styles.hidden} onLayout={(e) => setEnglishWidth(ScheduleType.Extra, e.nativeEvent.layout.width)}>
+          {EXTRAS_ENGLISH[getLongestPrayerNameIndex(ScheduleType.Extra)]}
+        </Text>
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  hidden: {
+    position: 'absolute',
+    pointerEvents: 'none',
+    opacity: 0,
+    fontFamily: TEXT.family.regular,
+    fontSize: TEXT.size,
+  },
+});

--- a/components/List.tsx
+++ b/components/List.tsx
@@ -1,81 +1,44 @@
 import { useAtomValue } from 'jotai';
 import { useRef } from 'react';
-import { View, Text, StyleSheet, LayoutChangeEvent } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 
 import ActiveBackground from '@/components/ActiveBackground';
 import Prayer from '@/components/Prayer';
-import { SCHEDULE_LENGTHS, SCREEN, TEXT, PRAYERS_ENGLISH, EXTRAS_ENGLISH } from '@/shared/constants';
-import { getLongestPrayerNameIndex } from '@/shared/prayer';
+import { SCHEDULE_LENGTHS, SCREEN, TEXT } from '@/shared/constants';
 import * as TimeUtils from '@/shared/time';
 import { ScheduleType } from '@/shared/types';
 import { setMeasurement } from '@/stores/overlay';
 import { dateAtom } from '@/stores/sync';
-import { setEnglishWidth, englishWidthStandardAtom, englishWidthExtraAtom } from '@/stores/ui';
 
 interface Props {
   type: ScheduleType;
 }
 
 export default function List({ type }: Props) {
-  useAtomValue(dateAtom); // Add this to make component reactive to date changes
-
+  useAtomValue(dateAtom);
   const isStandard = type === ScheduleType.Standard;
-  const storedWidth = useAtomValue(isStandard ? englishWidthStandardAtom : englishWidthExtraAtom);
   const listRef = useRef<View>(null);
 
-  // Calculate schedule length dynamically based on current date
   const scheduleLength = isStandard
     ? SCHEDULE_LENGTHS.standard
     : TimeUtils.isFriday()
       ? SCHEDULE_LENGTHS.extra
       : SCHEDULE_LENGTHS.extra - 1;
 
-  let longestPrayer: string | null = null;
-  if (storedWidth === 0) {
-    const longestIndex = getLongestPrayerNameIndex(type);
-    const prayers = isStandard ? PRAYERS_ENGLISH : EXTRAS_ENGLISH;
-    longestPrayer = prayers[longestIndex];
-  }
-
-  /**
-   * Measures the width of the longest prayer name to ensure consistent layout
-   * This hidden text component runs once on initial render and saves the width
-   * to persistent storage. The stored width is then used by all Prayer components
-   * to maintain equal column widths across the app.
-   */
-  const handleHiddenLayout = (e: LayoutChangeEvent) => {
-    if (storedWidth !== 0) return;
-
-    const { width } = e.nativeEvent.layout;
-    setEnglishWidth(type, width);
-  };
-
   const handleLayout = () => {
-    // Only measure 1st screen
     if (!listRef.current || !isStandard) return;
-
     listRef.current.measureInWindow((x, y, width, height) => {
       setMeasurement('list', { pageX: x, pageY: y, width, height });
     });
   };
 
   return (
-    <>
-      {/* Hidden text element only renders when we need to calculate the width */}
-      {storedWidth === 0 && (
-        <Text style={styles.hiddenText} onLayout={handleHiddenLayout}>
-          {longestPrayer}
-        </Text>
-      )}
-
-      {/* Main prayer list always renders */}
-      <View ref={listRef} onLayout={handleLayout} style={[styles.container]}>
-        <ActiveBackground type={type} />
-        {Array.from({ length: scheduleLength }).map((_, index) => (
-          <Prayer key={index} index={index} type={type} />
-        ))}
-      </View>
-    </>
+    <View ref={listRef} onLayout={handleLayout} style={[styles.container]}>
+      <ActiveBackground type={type} />
+      {Array.from({ length: scheduleLength }).map((_, index) => (
+        <Prayer key={index} index={index} type={type} />
+      ))}
+    </View>
   );
 }
 

--- a/components/List.tsx
+++ b/components/List.tsx
@@ -5,7 +5,6 @@ import { View, StyleSheet } from 'react-native';
 import ActiveBackground from '@/components/ActiveBackground';
 import Prayer from '@/components/Prayer';
 import { SCHEDULE_LENGTHS, SCREEN, TEXT } from '@/shared/constants';
-import * as TimeUtils from '@/shared/time';
 import { ScheduleType } from '@/shared/types';
 import { setMeasurement } from '@/stores/overlay';
 import { dateAtom } from '@/stores/sync';
@@ -15,15 +14,12 @@ interface Props {
 }
 
 export default function List({ type }: Props) {
-  useAtomValue(dateAtom);
+  useAtomValue(dateAtom); // Make component reactive to date changes
+
   const isStandard = type === ScheduleType.Standard;
   const listRef = useRef<View>(null);
 
-  const scheduleLength = isStandard
-    ? SCHEDULE_LENGTHS.standard
-    : TimeUtils.isFriday()
-      ? SCHEDULE_LENGTHS.extra
-      : SCHEDULE_LENGTHS.extra - 1;
+  const scheduleLength = isStandard ? SCHEDULE_LENGTHS.standard : SCHEDULE_LENGTHS.extra;
 
   const handleLayout = () => {
     if (!listRef.current || !isStandard) return;

--- a/components/Prayer.tsx
+++ b/components/Prayer.tsx
@@ -33,7 +33,7 @@ export default function Prayer({ type, index, isOverlay = false }: Props) {
   });
 
   const computedStyleEnglish = {
-    width: Prayer.ui.maxEnglishWidth + STYLES.prayer.padding.left || undefined, // Ensure consistent column width
+    width: Prayer.ui.maxEnglishWidth + STYLES.prayer.padding.left,
   };
 
   const handlePress = () => {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -12,7 +12,7 @@ export const NOTIFICATION_ROLLING_DAYS = 2;
 
 export const SCHEDULE_LENGTHS = {
   standard: PRAYERS_ENGLISH.length,
-  extra: TimeUtils.isFriday() ? EXTRAS_ENGLISH.length : 3, // remove Istijaba on non-Fridays
+  extra: TimeUtils.isFriday() ? EXTRAS_ENGLISH.length : EXTRAS_ENGLISH.length - 1, // remove Istijaba on non-Fridays
 };
 
 export const TIME_ADJUSTMENTS = {

--- a/stores/sync.ts
+++ b/stores/sync.ts
@@ -19,6 +19,7 @@ export const syncLoadable = loadable(atom(async () => sync()));
 export const dateAtom = atomWithStorageString('display_date', '');
 
 // --- Actions ---
+export const triggerSyncLoadable = () => store.get(syncLoadable);
 
 // Update the stored date based on the current schedule's Asr prayer time
 const setDate = () => {


### PR DESCRIPTION
This pull request includes several changes to improve the initialization and layout consistency of the app, particularly focusing on measuring and maintaining consistent column widths for prayer names. The most important changes include the addition of a new component for width measurement, updates to the layout effect for hiding the splash screen, and refactoring of the list component to remove redundant code.

Initialization and layout improvements:

* [`app/_layout.tsx`](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L4-R14): Replaced `useEffect` with `useLayoutEffect` for hiding the splash screen and added `InitialWidthMeasurement` component to measure and store the widths of the longest prayer names during app initialization. [[1]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L4-R14) [[2]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L26-R38)
* [`components/InitialWidthMeasurement.tsx`](diffhunk://#diff-01eee5ff764840f5f7a21676a01f99507b64ee6f89290083bcd5d81044954846R1-R46): Created a new component to measure the width of the longest prayer names for both standard and extra schedules, storing these measurements for consistent column widths across the app.

Refactoring and code cleanup:

* [`components/List.tsx`](diffhunk://#diff-130f9383837edf02a7976b3069f89bec105d4b0005a953ebbb16357e71dc2bf7L3-L78): Removed redundant code for measuring the width of the longest prayer names, as this functionality is now handled by the `InitialWidthMeasurement` component. Simplified the calculation of schedule lengths.
* [`components/Prayer.tsx`](diffhunk://#diff-43acb5c2c9a7b19a5f1b6a5c1c608f6be419f575820f9cc2772db204ea4ddeaeL36-R36): Ensured consistent column width by removing the fallback value in the `computedStyleEnglish` width calculation.
* [`shared/constants.ts`](diffhunk://#diff-3544a8dcc38f34717933ffd577d0377370a611411cd6f645685540c526713566L15-R15): Simplified the calculation of the extra schedule length by removing a redundant condition.
* [`stores/sync.ts`](diffhunk://#diff-c9c61a13f7b3fd60377c42c6a19a125a9bcf6eb01bb4367f927c608e79db09aaR22): Added a `triggerSyncLoadable` function to trigger synchronization during app initialization.