### PR TITLE
added open source MIT license

### DIFF
--- a/components/List.tsx
+++ b/components/List.tsx
@@ -4,7 +4,8 @@ import { View, StyleSheet } from 'react-native';
 
 import ActiveBackground from '@/components/ActiveBackground';
 import Prayer from '@/components/Prayer';
-import { SCHEDULE_LENGTHS, SCREEN, TEXT } from '@/shared/constants';
+import { EXTRAS_ENGLISH, SCREEN, TEXT, PRAYERS_ENGLISH } from '@/shared/constants';
+import * as TimeUtils from '@/shared/time';
 import { ScheduleType } from '@/shared/types';
 import { dateAtom } from '@/stores/sync';
 import { getMeasurementsList, setMeasurementsList } from '@/stores/ui';
@@ -19,7 +20,11 @@ export default function List({ type }: Props) {
   const isStandard = type === ScheduleType.Standard;
   const listRef = useRef<View>(null);
 
-  const scheduleLength = isStandard ? SCHEDULE_LENGTHS.standard : SCHEDULE_LENGTHS.extra;
+  const scheduleLength = isStandard
+    ? PRAYERS_ENGLISH.length
+    : TimeUtils.isFriday()
+      ? EXTRAS_ENGLISH.length
+      : EXTRAS_ENGLISH.length - 1; // Exclude Istijaba on non-Friday
 
   const handleLayout = () => {
     if (!listRef.current || !isStandard) return;

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,5 +1,3 @@
-import * as TimeUtils from '@/shared/time';
-
 export const PRAYERS_ENGLISH = ['Fajr', 'Sunrise', 'Dhuhr', 'Asr', 'Magrib', 'Isha'];
 export const PRAYERS_ARABIC = ['الفجر', 'الشروق', 'الظهر', 'العصر', 'المغرب', 'العشاء'];
 export const PRAYER_INDEX_ASR = 3; // Used to display the date
@@ -9,11 +7,6 @@ export const EXTRAS_ARABIC = ['آخر ثلث', 'السحور', 'الضحى', 'ا
 export const ISTIJABA_INDEX = 3;
 
 export const NOTIFICATION_ROLLING_DAYS = 2;
-
-export const SCHEDULE_LENGTHS = {
-  standard: PRAYERS_ENGLISH.length,
-  extra: TimeUtils.isFriday() ? EXTRAS_ENGLISH.length : EXTRAS_ENGLISH.length - 1, // remove Istijaba on non-Fridays
-};
 
 export const TIME_ADJUSTMENTS = {
   suhoor: -40, // minutes before fajr

--- a/shared/prayer.ts
+++ b/shared/prayer.ts
@@ -5,7 +5,6 @@ import {
   EXTRAS_ARABIC,
   TIME_ADJUSTMENTS,
   ANIMATION,
-  SCHEDULE_LENGTHS,
 } from '@/shared/constants';
 import * as TimeUtils from '@/shared/time';
 import { ISingleApiResponseTransformed, IScheduleNow, IApiResponse, IApiTimes, ScheduleType } from '@/shared/types';
@@ -113,7 +112,7 @@ export const findNextPrayerIndex = (schedule: IScheduleNow): number => {
 // UI Helpers
 export const getCascadeDelay = (index: number, type: ScheduleType): number => {
   const isStandard = type === ScheduleType.Standard;
-  const length = isStandard ? SCHEDULE_LENGTHS.standard : SCHEDULE_LENGTHS.extra;
+  const length = isStandard ? PRAYERS_ENGLISH.length : PRAYERS_ARABIC.length;
 
   return (length - index) * ANIMATION.cascadeDelay;
 };


### PR DESCRIPTION
This pull request includes several changes to the `components/List.tsx`, `shared/constants.ts`, and `shared/prayer.ts` files to improve the handling of prayer schedules and remove redundant constants. The most important changes include updating the import statements, modifying the logic for determining schedule lengths, and removing unnecessary constants.

### Changes to import statements:

* [`components/List.tsx`](diffhunk://#diff-130f9383837edf02a7976b3069f89bec105d4b0005a953ebbb16357e71dc2bf7L7-R8): Updated import statements to include `EXTRAS_ENGLISH`, `PRAYERS_ENGLISH`, and `TimeUtils` from `@/shared/constants` and `@/shared/time`.

### Modifications to schedule length logic:

* [`components/List.tsx`](diffhunk://#diff-130f9383837edf02a7976b3069f89bec105d4b0005a953ebbb16357e71dc2bf7L22-R27): Updated the logic for determining `scheduleLength` to use `PRAYERS_ENGLISH.length` for standard schedules and `EXTRAS_ENGLISH.length` or `EXTRAS_ENGLISH.length - 1` for extra schedules based on whether it is Friday.
* [`shared/prayer.ts`](diffhunk://#diff-6aca9aaf25764d354b9e799cdb7578157f2ab235ae6545a0ceb0e179217dc94dL116-R115): Updated the `getCascadeDelay` function to use `PRAYERS_ENGLISH.length` for standard schedules and `PRAYERS_ARABIC.length` for extra schedules.

### Removal of redundant constants:

* [`shared/constants.ts`](diffhunk://#diff-3544a8dcc38f34717933ffd577d0377370a611411cd6f645685540c526713566L13-L17): Removed the `SCHEDULE_LENGTHS` constant as its functionality was replaced by direct usage of `PRAYERS_ENGLISH.length` and `EXTRAS_ENGLISH.length`.
* [`shared/prayer.ts`](diffhunk://#diff-6aca9aaf25764d354b9e799cdb7578157f2ab235ae6545a0ceb0e179217dc94dL8): Removed the import of `SCHEDULE_LENGTHS` from `@/shared/constants`.