### PR TITLE
Silent notif

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ The project uses ESLint and Prettier for code consistency and quality:
 - `popup_tip_athan_enabled`: First-time tips popup state
 - `popup_times_explained_enabled`: Prayer times explanation popup state
 - `popup_update_last_check`: Timestamp of last app update check
+- `silent_notification_sent`: Track if time-sensitive permission prompt was triggered
 
 ### Screenshots
 

--- a/components/ModalTimesExplained.tsx
+++ b/components/ModalTimesExplained.tsx
@@ -15,7 +15,7 @@ export default function ModalTimesExplained({ visible, onClose }: Props) {
   useEffect(() => {
     if (visible) {
       setIsDisabled(true);
-      const timer = setTimeout(() => setIsDisabled(false), 4000);
+      const timer = setTimeout(() => setIsDisabled(false), 5000);
       return () => clearTimeout(timer);
     }
   }, [visible]);

--- a/components/ModalTips.tsx
+++ b/components/ModalTips.tsx
@@ -18,7 +18,7 @@ export default function ModalTips({ visible, onClose }: Props) {
   useEffect(() => {
     if (visible) {
       setIsDisabled(true);
-      const timer = setTimeout(() => setIsDisabled(false), 4000);
+      const timer = setTimeout(() => setIsDisabled(false), 5000);
       return () => clearTimeout(timer);
     }
   }, [visible]);

--- a/device/notifications.ts
+++ b/device/notifications.ts
@@ -69,3 +69,22 @@ export const clearAllScheduledNotificationForPrayer = async (scheduleType: Sched
 
   logger.info('NOTIFICATION SYSTEM: Cancelled all notifications for prayer:', { scheduleType, prayerIndex });
 };
+
+export const sendSilentNotification = async () => {
+  if (Platform.OS !== 'ios') return;
+
+  try {
+    await Notifications.scheduleNotificationAsync({
+      content: {
+        title: '',
+        body: '',
+        sound: false,
+        interruptionLevel: 'timeSensitive',
+      },
+      trigger: null,
+    });
+    logger.info('NOTIFICATION SYSTEM: Sent silent notification for iOS time-sensitive permissions');
+  } catch (error) {
+    logger.error('NOTIFICATION SYSTEM: Failed to send silent notification:', error);
+  }
+};

--- a/device/notifications.ts
+++ b/device/notifications.ts
@@ -70,6 +70,25 @@ export const clearAllScheduledNotificationForPrayer = async (scheduleType: Sched
   logger.info('NOTIFICATION SYSTEM: Cancelled all notifications for prayer:', { scheduleType, prayerIndex });
 };
 
+/**
+ * Sends an immediate silent notification on iOS to trigger the time-sensitive permissions prompt.
+ *
+ * Problem:
+ * On iOS, the time-sensitive permission dialog only appears when the first time-sensitive
+ * notification is delivered. This creates a poor UX since the user wouldn't see the prompt
+ * until hours later when the first prayer notification triggers.
+ *
+ * Solution:
+ * We send an empty notification with time-sensitive interruption level immediately after
+ * the user grants standard notification permissions. This makes the time-sensitive prompt
+ * appear right away, giving the user a better onboarding experience.
+ *
+ * Note:
+ * - iOS only (function returns early on Android)
+ * - Uses null trigger for immediate delivery
+ * - No sound or visual elements to minimize user disruption
+ * - Should only be called once after standard permissions are granted
+ */
 export const sendSilentNotification = async () => {
   if (Platform.OS !== 'ios') return;
 

--- a/hooks/useNotification.ts
+++ b/hooks/useNotification.ts
@@ -1,9 +1,12 @@
 import * as Notifications from 'expo-notifications';
+import { useAtomValue } from 'jotai';
 import { Platform, Alert, Linking } from 'react-native';
 
+import { sendSilentNotification } from '@/device/notifications';
 import logger from '@/shared/logger';
 import { AlertType, ScheduleType } from '@/shared/types';
 import * as NotificationStore from '@/stores/notifications';
+import { silentNotificationSentAtom, setSilentNotificationSent } from '@/stores/ui';
 
 // Configure notifications to show when app is foregrounded
 Notifications.setNotificationHandler({
@@ -15,6 +18,8 @@ Notifications.setNotificationHandler({
 });
 
 export const useNotification = () => {
+  const silentNotificationSent = useAtomValue(silentNotificationSentAtom);
+
   const isNotifictionGranted = async (status: string) => status === 'granted';
 
   const checkInitialPermissions = async () => {
@@ -22,14 +27,21 @@ export const useNotification = () => {
       const { status: existingStatus } = await Notifications.getPermissionsAsync();
 
       if (existingStatus !== 'granted') {
-        const { status } = await Notifications.requestPermissionsAsync({
-          ios: {
-            allowAlert: true,
-            allowBadge: true,
-            allowSound: true,
-          },
-        });
+        const { status } = await Notifications.requestPermissionsAsync();
+
+        // If permissions granted and on iOS, trigger time-sensitive permission
+        if (status === 'granted' && Platform.OS === 'ios' && !silentNotificationSent) {
+          await sendSilentNotification();
+          setSilentNotificationSent(true);
+        }
+
         return isNotifictionGranted(status);
+      }
+
+      // Handle case where permissions were already granted
+      if (Platform.OS === 'ios' && !silentNotificationSent) {
+        await sendSilentNotification();
+        setSilentNotificationSent(true);
       }
 
       return isNotifictionGranted(existingStatus);

--- a/shared/notifications.ts
+++ b/shared/notifications.ts
@@ -51,7 +51,7 @@ export const genNotificationContent = (
     autoDismiss: false,
     sticky: false,
     priority: Notifications.AndroidNotificationPriority.MAX,
-    interruptionLevel: 'active',
+    interruptionLevel: 'timeSensitive',
   };
 };
 

--- a/stores/ui.ts
+++ b/stores/ui.ts
@@ -31,6 +31,8 @@ export const englishWidthExtraAtom = atomWithStorageNumber('prayer_max_english_w
 export const measurementsListAtom = atomWithStorageObject<PageCoordinates>('measurements_list', emptyCoordinates);
 export const measurementsDateAtom = atomWithStorageObject<PageCoordinates>('measurements_date', emptyCoordinates);
 
+export const silentNotificationSentAtom = atomWithStorageBoolean('silent_notification_sent', false);
+
 export const tempStandardMutedAtom = atom<boolean | null>(null);
 export const tempExtraMutedAtom = atom<boolean | null>(null);
 
@@ -69,3 +71,5 @@ export const getMeasurementsList = () => store.get(measurementsListAtom);
 export const setMeasurementsList = (measurements: PageCoordinates) => store.set(measurementsListAtom, measurements);
 export const getMeasurementsDate = () => store.get(measurementsDateAtom);
 export const setMeasurementsDate = (measurements: PageCoordinates) => store.set(measurementsDateAtom, measurements);
+
+export const setSilentNotificationSent = (sent: boolean) => store.set(silentNotificationSentAtom, sent);


### PR DESCRIPTION
This pull request includes several changes to improve the notification system and enhance the user experience by addressing the time-sensitive permission prompt on iOS. Additionally, it includes minor adjustments to existing components and updates to the documentation.

### Notification System Enhancements:

* Added a new function `sendSilentNotification` in `device/notifications.ts` to trigger the time-sensitive permission prompt immediately after standard permissions are granted on iOS.
* Updated `useNotification` hook in `hooks/useNotification.ts` to use the new `sendSilentNotification` function and track if the silent notification has been sent using a new atom `silentNotificationSentAtom`. [[1]](diffhunk://#diff-ac570c0e785212441509e5fc068638908f6ecefca6cd0d21eab613b6edec6efcR2-R9) [[2]](diffhunk://#diff-ac570c0e785212441509e5fc068638908f6ecefca6cd0d21eab613b6edec6efcR21-R46)
* Added `silentNotificationSentAtom` and `setSilentNotificationSent` in `stores/ui.ts` to manage the state of whether the silent notification has been sent. [[1]](diffhunk://#diff-038469d15faafedd09823343f17da186b5d25504cbef7d6a91b01faaab27a244R34-R35) [[2]](diffhunk://#diff-038469d15faafedd09823343f17da186b5d25504cbef7d6a91b01faaab27a244R74-R75)

### Code Consistency and Quality:

* Updated the `README.md` file to include a new state `silent_notification_sent` for tracking if the time-sensitive permission prompt was triggered.

### Minor Adjustments:

* Increased the timeout duration from 4000ms to 5000ms in `ModalTimesExplained.tsx` and `ModalTips.tsx` to improve user experience. [[1]](diffhunk://#diff-75885b3086c2cba07023193f62dcf4ce0296163e20900e0532b35000721a926cL18-R18) [[2]](diffhunk://#diff-7f639e159fa28c0d8a3478de892630708bbcf107dd4aca369ec137c67bb74e5dL21-R21)
* Changed the `interruptionLevel` from `active` to `timeSensitive` in `shared/notifications.ts` to ensure notifications are delivered with the correct priority level.